### PR TITLE
Tracker uses ipv4 even when the ipv config is 6 in some cases.

### DIFF
--- a/ipv6-dns-workaround.js
+++ b/ipv6-dns-workaround.js
@@ -2,6 +2,6 @@ const dns = require('dns');
 
 const { lookup } = dns;
 dns.lookup = (name, opts, cb) => {
-  if (typeof cb !== 'function') return lookup(name, { verbatim: true }, opts);
-  return lookup(name, Object.assign({ verbatim: true }, opts), cb);
+  if (typeof cb !== 'function') return lookup(name, { verbatim: true, family: 6 }, opts);
+  return lookup(name, Object.assign({ }, opts, { verbatim: true, family: 6 }), cb);
 };


### PR DESCRIPTION
Set dns lookup family to 6 to make sure the tracker uses ipv6.