### PR TITLE
Update zencfg.js

### DIFF
--- a/zencfg.js
+++ b/zencfg.js
@@ -84,8 +84,7 @@ exports.getZenConfig = () => {
     process.exit();
   }
   if (!zencfg.port) {
-    console.log('Port not found in zen.conf. Add \'port=9033\' for mainnet or \'port=19033\' for testnet');
-    process.exit();
+    zencfg.port = testnet ? '19033' : '9033';
   }
 
   return zencfg;


### PR DESCRIPTION
Use zend port defaults when `port=...` is missing from zen.conf