### PR TITLE
Added logging for low balances

### DIFF
--- a/SNodeTracker.js
+++ b/SNodeTracker.js
@@ -143,6 +143,9 @@ class SNode {
                   };
                   break;
                 }
+                else if (zaddr.bal <= self.minChalBal) {
+                  console.log(`Balance of ${zaddr.bal} for address ${zaddr.addr} must be greater than ${self.minChalBal}`);
+                }
               }
             }
             if (obj) return cb(null, obj);


### PR DESCRIPTION
When the balance of one of the challenge addresses reaches 0.001, tracker client fails to start without a useful error. See https://gist.github.com/rmeleromira/3ff67ad3980fda0bdfa54bdf2ae2205e for a detail of the error